### PR TITLE
alias_method_chain is no more. now using Ruby 2+ prepend

### DIFF
--- a/lib/topmodel/callbacks.rb
+++ b/lib/topmodel/callbacks.rb
@@ -1,5 +1,31 @@
 module TopModel
   module Callbacks
+    module ClassMethods
+      def create
+        run_callbacks :create do
+          super
+        end
+      end
+
+      def save
+        run_callbacks :save do
+          super
+        end
+      end
+
+      def update
+        run_callbacks :update do
+          super
+        end
+      end
+
+      def destroy
+        run_callbacks :destroy do
+          super
+        end
+      end
+    end
+
     extend ActiveSupport::Concern
 
     included do
@@ -8,41 +34,9 @@ module TopModel
         define_model_callbacks :create, :save, :update, :destroy
       end
 
-      # Callback Fixes https://raw.githubusercontent.com/locomotivapro/topmodel/33d952c5082245465f9f063a55a743b88df7558d/lib/topmodel/callbacks.rb
-      class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def create_with_callbacks(*args, &block)
-          run_callbacks :create do
-            # Your create action methods here
-            create_without_callbacks(*args, &block)
-          end
-        end
-        alias_method_chain(:create, :callbacks)
-
-        def save_with_callbacks(*args, &block)
-          run_callbacks :save do
-            # Your save action methods here
-            save_without_callbacks(*args, &block)
-          end
-        end
-        alias_method_chain(:save, :callbacks)
-
-        def update_with_callbacks(*args, &block)
-          run_callbacks :update do
-            # Your update action methods here
-            update_without_callbacks(*args, &block)
-          end
-        end
-        alias_method_chain(:update, :callbacks)
-
-        def destroy_with_callbacks(*args, &block)
-          run_callbacks :destroy do
-            # Your destroy action methods here
-            destroy_without_callbacks(*args, &block)
-          end
-        end
-        alias_method_chain(:destroy, :callbacks)
-      EOS
-      
+      class_eval do
+        prepend TopModel::Callbacks::ClassMethods
+      end
     end
   end
 end

--- a/lib/topmodel/dirty.rb
+++ b/lib/topmodel/dirty.rb
@@ -3,22 +3,29 @@ module TopModel
     extend ActiveSupport::Concern
     include ActiveModel::Dirty
 
-    included do
-      %w( create update ).each do |method|
-        class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-          def #{method}_with_dirty(*args, &block)
-            result = #{method}_without_dirty(*args, &block)
-            save_previous_changes
-            result
-          end
-        EOS
-        alias_method_chain(method, :dirty)
+    module ClassMethods
+      def create(*args, &block)
+        result = super(*args, &block)
+        save_previous_changes
+        result
+      end
+
+      def update(*args, &block)
+        result = super(*args, &block)
+        save_previous_changes
+        result
       end
     end
-        
-    def save_previous_changes
-      @previously_changed = changes
-      @changed_attributes.clear
+
+    included do
+      class_eval do
+        prepend ClassMethods
+
+        def save_previous_changes
+          @previously_changed = changes
+          @changed_attributes.clear
+        end
+      end
     end
   end
 end

--- a/lib/topmodel/validations.rb
+++ b/lib/topmodel/validations.rb
@@ -3,28 +3,30 @@ module TopModel
     extend  ActiveSupport::Concern
     include ActiveModel::Validations
 
-    included do
-      alias_method_chain :save, :validation
-    end
-  
-    def save_with_validation(options = nil)
-      perform_validation = case options
-      when Hash
-        options[:validate] != false
-      when NilClass
-        true
-      else
-        options
-      end
-    
-      if perform_validation && valid? || !perform_validation
-        save_without_validation
-        true
-      else
+    module InstanceMethods
+      def save(options = nil)
+        perform_validation = case options
+        when Hash
+          options[:validate] != false
+        when NilClass
+          true
+        else
+          options
+        end
+
+        if perform_validation && valid? || !perform_validation
+          super()
+          true
+        else
+          false
+        end
+      rescue InvalidRecord => error
         false
       end
-    rescue InvalidRecord => error
-      false
+    end
+
+    included do
+      prepend TopModel::Validations::InstanceMethods
     end
   end
 end


### PR DESCRIPTION
The existing code no longer works with Rails. Rails 5 abandoned `alias_method_chain`. The new way is to use Ruby's `prepend`.